### PR TITLE
Bug fix due to inconsistent msh API.

### DIFF
--- a/src/load_msh_data.cpp
+++ b/src/load_msh_data.cpp
@@ -41,7 +41,14 @@ namespace v41 {
 void load_data_entry(
     std::istream& in, DataEntry& entry, size_t fields_per_entry, bool is_element_node_data)
 {
-    in.read(reinterpret_cast<char*>(&entry.tag), sizeof(size_t));
+    // TODO:
+    // Based on trial and error, it seems Gmsh 4.7.1 still expect 32
+    // bits tag, which is inconsistent with their spec.  Maybe
+    // report a bug?
+    int32_t tag_32;
+    in.read(reinterpret_cast<char*>(&tag_32), 4);
+    entry.tag = static_cast<size_t>(tag_32);
+    // in.read(reinterpret_cast<char*>(&entry.tag), sizeof(size_t));
     if (is_element_node_data) {
         in.read(reinterpret_cast<char*>(&entry.num_nodes_per_element), sizeof(int));
         entry.data.resize(fields_per_entry * static_cast<size_t>(entry.num_nodes_per_element));

--- a/src/save_msh_data.cpp
+++ b/src/save_msh_data.cpp
@@ -35,8 +35,15 @@ void save_data(std::ostream& out,
 
     if (is_binary) {
         if (version == "4.1") {
+            int32_t tag;
             for (const DataEntry& entry : data.entries) {
-                out.write(reinterpret_cast<const char*>(&entry.tag), sizeof(size_t));
+                // TODO:
+                // Based on trial and error, it seems Gmsh 4.7.1 still expect 32
+                // bits tag, which is inconsistent with their spec.  Maybe
+                // report a bug?
+                tag = static_cast<int32_t>(entry.tag);
+                out.write(reinterpret_cast<const char*>(&tag), 4);
+                // out.write(reinterpret_cast<const char*>(&entry.tag), sizeof(size_t));
                 if (is_element_node_data) {
                     out.write(
                         reinterpret_cast<const char*>(&entry.num_nodes_per_element), sizeof(int));


### PR DESCRIPTION
Summary:
* Bug fix in inconsistent msh 4.1 binary API.

E.g. The [current API](https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format) has the following line:
```
elementTag(size_t) value(double) ...
```
where `elementTag` should be stored using `sizeof(size_t)` bytes, which is 8 on macbook.  However, this causes the data field to be incorrectly parsed by Gmsh 4.7.1 (released on 16 November 2020).  It seems Gmsh is still expecting 4 bytes for representing element/node tags in `ElementData` and `NodeData` section.