### PR TITLE
Add support for the $PhysicalNames section

### DIFF
--- a/examples/msh_inspect.cpp
+++ b/examples/msh_inspect.cpp
@@ -14,6 +14,14 @@ int main(int argc, char** argv)
     std::cout << "sizeof(int): " << sizeof(int) << std::endl;
     std::cout << "sizeof(size_t) " << sizeof(size_t) << std::endl;
     std::cout << "sizeof(double) " << sizeof(double) << std::endl;
+
+    std::cout << "Num physical groups: " << spec.physical_groups.size() << std::endl;
+    for (const auto& group: spec.physical_groups) {
+        std::cout << "  group dim: " << group.dim << std::endl;
+        std::cout << "  group tag: " << group.tag << std::endl;
+        std::cout << "  group name: " << std::quoted(group.name) << std::endl;
+    }
+
     std::cout << "Num nodes: " << spec.nodes.num_nodes << std::endl;
     std::cout << "Num node blocks: " << spec.nodes.num_entity_blocks << std::endl;
     std::cout << "min node tag: " << spec.nodes.min_node_tag << std::endl;

--- a/include/MshIO/MshSpec.h
+++ b/include/MshIO/MshSpec.h
@@ -71,11 +71,19 @@ struct Data
     std::vector<DataEntry> entries;
 };
 
+struct PhysicalGroup
+{
+    int dim = 0;
+    int tag = 0;
+    std::string name;
+};
+
 struct MshSpec
 {
     MeshFormat mesh_format;
     Nodes nodes;
     Elements elements;
+    std::vector<PhysicalGroup> physical_groups;
     std::vector<Data> node_data;
     std::vector<Data> element_data;
     std::vector<Data> element_node_data;

--- a/src/load_msh.cpp
+++ b/src/load_msh.cpp
@@ -7,6 +7,7 @@
 #include "load_msh_nanospline_format.h"
 #include "load_msh_nodes.h"
 #include "load_msh_patches.h"
+#include "load_msh_physical_groups.h"
 #include "load_msh_post_process.h"
 
 #include <cassert>
@@ -36,6 +37,8 @@ MshSpec load_msh(std::istream& in)
         end_str = "$End" + buf.substr(1);
         if (buf == "$MeshFormat") {
             load_mesh_format(in, spec);
+        } else if (buf == "$PhysicalNames") {
+            load_physical_groups(in, spec);
         } else if (buf == "$Nodes") {
             load_nodes(in, spec);
         } else if (buf == "$Elements") {

--- a/src/load_msh_physical_groups.cpp
+++ b/src/load_msh_physical_groups.cpp
@@ -1,0 +1,27 @@
+#include "load_msh_physical_groups.h"
+
+#include <MshIO/MshSpec.h>
+
+#include <cassert>
+#include <fstream>
+#include <iomanip>
+#include <string>
+
+namespace mshio {
+
+void load_physical_groups(std::istream& in, MshSpec& spec)
+{
+    auto& groups = spec.physical_groups;
+    int num_groups;
+    in >> num_groups;
+    spec.physical_groups.resize(num_groups);
+    for (int i = 0; i < num_groups; i++) {
+        auto& group = groups[i];
+        in >> group.dim;
+        in >> group.tag;
+        in >> std::quoted(group.name);
+    }
+    assert(in.good());
+}
+
+} // namespace mshio

--- a/src/load_msh_physical_groups.h
+++ b/src/load_msh_physical_groups.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <MshIO/MshSpec.h>
+#include <iostream>
+
+namespace mshio {
+
+void load_physical_groups(std::istream& in, MshSpec& spec);
+
+} // namespace mshio

--- a/src/save_msh.cpp
+++ b/src/save_msh.cpp
@@ -6,6 +6,7 @@
 #include "save_msh_format.h"
 #include "save_msh_nodes.h"
 #include "save_msh_patches.h"
+#include "save_msh_physical_groups.h"
 #include "save_msh_nanospline_format.h"
 
 #include <cassert>
@@ -16,6 +17,9 @@ namespace mshio {
 void save_msh(std::ostream& out, const MshSpec& spec)
 {
     save_mesh_format(out, spec);
+    if (spec.physical_groups.size() > 0) {
+        save_physical_groups(out, spec);
+    }
     if (spec.nodes.num_nodes > 0) {
         save_nodes(out, spec);
     }

--- a/src/save_msh_physical_groups.cpp
+++ b/src/save_msh_physical_groups.cpp
@@ -1,0 +1,25 @@
+#include "save_msh_physical_groups.h"
+
+#include <MshIO/MshSpec.h>
+#include <MshIO/exception.h>
+
+#include <cassert>
+#include <iomanip>
+
+namespace mshio {
+
+void save_physical_groups(std::ostream& out, const MshSpec& spec)
+{
+    out << "$PhysicalNames" << std::endl;
+    const auto& groups = spec.physical_groups;
+    out << groups.size() << std::endl;
+
+    for (const auto& group: groups) {
+        out << group.dim << " ";
+        out << group.tag << " ";
+        out << std::quoted(group.name) << std::endl;
+    }
+    out << "$EndPhysicalNames" << std::endl;
+}
+
+} // namespace mshio

--- a/src/save_msh_physical_groups.h
+++ b/src/save_msh_physical_groups.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <MshIO/MshSpec.h>
+#include <ostream>
+
+namespace mshio {
+
+void save_physical_groups(std::ostream& out, const MshSpec& spec);
+
+}


### PR DESCRIPTION
This PR adds support for loading and saving the `$PhysicalNames` section. The section is simple in isolation and is identical for the both versions 2.2 and 4.1 (ascii and binary). 

There is further work required to associate elements with physical groups.  I held off documenting this feature until groups are fully supported (e.g. as part of elements).  There are also no tests yet, but I ran a couple of quick tests using `msh_inspect` and everything seemed OK. How this section is interpreted in combination with the other sections is different between 2 and 4. In version 4, elements have an entity which then may have a physical group. Version 2 instead stores the physical group tag with each element.

Even though the section is called `$PhysicalNames`, I instead used `PhysicalGroups` in the code, since I believe it's the more common term in the Gmsh reference materials (e.g. https://gmsh.info/doc/texinfo/gmsh.html#Elementary-entities-vs-physical-groups, http://gmsh.info/doc/texinfo/gmsh.html#index-gmsh_002fmodel_002fgetPhysicalGroups). If you'd like changes to the name or any other part of the code I would be happy to make them. Thank you for this very nice library!