### PR TITLE
Write out ascii block info on one line like Gmsh

### DIFF
--- a/src/save_msh_elements.cpp
+++ b/src/save_msh_elements.cpp
@@ -19,17 +19,14 @@ namespace v41 {
 void save_elements_ascii(std::ostream& out, const MshSpec& spec)
 {
     const Elements& elements = spec.elements;
-    out << elements.num_entity_blocks << std::endl;
-    out << elements.num_elements << std::endl;
-    out << elements.min_element_tag << " " << elements.max_element_tag << std::endl;
+    out << elements.num_entity_blocks << " " << elements.num_elements << " "
+        << elements.min_element_tag << " " << elements.max_element_tag << std::endl;
 
     for (size_t i = 0; i < elements.num_entity_blocks; i++) {
         const ElementBlock& block = elements.entity_blocks[i];
 
-        out << block.entity_dim << std::endl;
-        out << block.entity_tag << std::endl;
-        out << block.element_type << std::endl;
-        out << block.num_elements_in_block << std::endl;
+        out << block.entity_dim << " " << block.entity_tag << " "
+            << block.element_type << " " << block.num_elements_in_block << std::endl;
 
         const size_t n = nodes_per_element(block.element_type);
         for (size_t j = 0; j < block.num_elements_in_block; j++) {

--- a/src/save_msh_nodes.cpp
+++ b/src/save_msh_nodes.cpp
@@ -13,9 +13,8 @@ namespace v41 {
 void save_nodes_ascii(std::ostream& out, const MshSpec& spec)
 {
     const Nodes& nodes = spec.nodes;
-    out << nodes.num_entity_blocks << std::endl;
-    out << nodes.num_nodes << std::endl;
-    out << nodes.min_node_tag << " " << nodes.max_node_tag << std::endl;
+    out << nodes.num_entity_blocks << " " << nodes.num_nodes << " "
+        << nodes.min_node_tag << " " << nodes.max_node_tag << std::endl;
 
     for (size_t i = 0; i < nodes.num_entity_blocks; i++) {
         const NodeBlock& block = nodes.entity_blocks[i];


### PR DESCRIPTION
This reduces the diff between MshIO written files and those generated by Gmsh itself.

Diff output before on a simple msh file roundtripped through `msh_inspect`:
```diff
± diff input.msh tmp.msh
4,7d3
< $Entities
< 0 0 0 1
< 1 0 0 0 0 0 0 1 1 0
< $EndEntities
13c9,11
< 1 8 1 8
---
> 1
> 8
> 1 8
33,34c31,37
< 1 5 1 5
< 3 1 4 5
---
> 1
> 5
> 1 5
> 3
> 1
> 4
> 5
```

after (just the unsupported `$Entities` section, as expected): 
```diff 
± diff input.msh tmp.msh
4,7d3
< $Entities
< 0 0 0 1
< 1 0 0 0 0 0 0 1 1 0
< $EndEntities
```