### PR TITLE
Add support for $Entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ the following sections are supported:
 |       [Mesh format] | Format header.                                                               |
 |             [Nodes] | 3D coordinates of nodes and (optionally) their parameterization coordinates. |
 |          [Elements] | A list of elements grouped by blocks.                                        |
+|          [Entities] | The boundary representation (BRep) of the model.                             |
 |         [Node data] | Scalar/vector/tensor fields defined on nodes.                                |
 |      [Element data] | Scalar/vector/tensor fields defined on elements.                             |
 | [Element-node data] | Scalar/vector/tensor fields defined over each node of each element.          |
@@ -34,7 +35,6 @@ the following sections are supported:
 The follow sections are supported by MSH format, but not yet supported by MshIO
 (contribution welcomed):
 * Physical names
-* Entities
 * Partitioned entities
 * Periodic
 * Ghost elements
@@ -157,6 +157,32 @@ i.e. Each element entry consists of an element tag followed by `n` node tags,
 where `n` is the number of nodes corresponding determined by the element type.
 See the [supported element types](#Supported-element-types) table.
 
+### Entities
+
+Entities make up the boundary representation of the mesh model. Nodes and
+elements belong to specific entities. The four types of entities are points,
+lines, surfaces and volumes. Higher order entities are bounded by lower ones
+(e.g. volumes are bounded by surfaces). Entities also contain bounding box and
+physical group information.
+
+```c++
+auto& entities = spec.entities;
+auto& point_entities = entities.points;
+auto& curve_entities = entities.curves;
+auto& surface_entities = entities.surfaces;
+auto& volume_entities = entities.volumes;
+
+// look up the physical groups of an element block
+auto& block = elements.entity_blocks[i];
+assert(block.entity_dim == 2); // surface entity (0 for point, 1 for curve...)
+auto surface_entity = std::find_if(surface_entities.begin(),
+    surface_entities.end(), [&](const mshio::SurfaceEntity& s) {
+    return s.tag == block.entity_tag;
+});
+assert(surface_entity != surface_entities.end());
+auto& physical_groups = surface_entity->physical_group_tags;
+```
+
 ### Post-processing data
 
 One of main advantage of MSH format is its support for storing post-processing
@@ -257,3 +283,4 @@ The following types are supported by MshIO:
 [Node data]: #Post-processing-data
 [Element data]: #Post-processing-data
 [Element-node data]: #Post-processing-data
+[Entities]: #Entities

--- a/examples/msh_inspect.cpp
+++ b/examples/msh_inspect.cpp
@@ -15,6 +15,103 @@ int main(int argc, char** argv)
     std::cout << "sizeof(size_t) " << sizeof(size_t) << std::endl;
     std::cout << "sizeof(double) " << sizeof(double) << std::endl;
 
+    std::cout << "Num point entities: " << spec.entities.points.size() << std::endl;
+    for (const auto& point: spec.entities.points) {
+        std::cout << "  entity tag: " << point.tag << std::endl;
+        std::cout << "  entity coordinates: " << point.x <<
+            " " << point.y << " " << point.z << std::endl;
+        size_t num_groups = point.physical_group_tags.size();
+        std::cout << "  Num physical groups: " << num_groups << std::endl;
+        if (num_groups > 0) {
+            std::cout << "    ";
+            for (size_t i = 0; i < num_groups; i++) {
+                std::cout << point.physical_group_tags[i] << " ";
+            }
+            std::cout << std::endl;
+        }
+    }
+
+    std::cout << "Num curve entities: " << spec.entities.curves.size() << std::endl;
+    for (const auto& curve: spec.entities.curves) {
+        std::cout << "  entity tag: " << curve.tag << std::endl;
+        std::cout << "  bounding box min: " << curve.min_x <<
+            " " << curve.min_y << " " << curve.min_z << std::endl;
+        std::cout << "  bounding box max: " << curve.max_x <<
+            " " << curve.max_y << " " << curve.max_z << std::endl;
+        size_t num_groups = curve.physical_group_tags.size();
+        std::cout << "  Num physical groups: " << num_groups << std::endl;
+        if (num_groups > 0) {
+            std::cout << "    ";
+            for (size_t i = 0; i < num_groups; i++) {
+                std::cout << curve.physical_group_tags[i] << " ";
+            }
+            std::cout << std::endl;
+        }
+        size_t num_bounds = curve.boundary_point_tags.size();
+        std::cout << "  Num boundary points: " << num_bounds << std::endl;
+        if (num_bounds > 0) {
+            std::cout << "    ";
+            for (size_t i = 0; i < num_bounds; i++) {
+                std::cout << curve.boundary_point_tags[i] << " ";
+            }
+            std::cout << std::endl;
+        }
+    }
+
+    std::cout << "Num surface entities: " << spec.entities.surfaces.size() << std::endl;
+    for (const auto& surface: spec.entities.surfaces) {
+        std::cout << "  entity tag: " << surface.tag << std::endl;
+        std::cout << "  bounding box min: " << surface.min_x <<
+            " " << surface.min_y << " " << surface.min_z << std::endl;
+        std::cout << "  bounding box max: " << surface.max_x <<
+            " " << surface.max_y << " " << surface.max_z << std::endl;
+        size_t num_groups = surface.physical_group_tags.size();
+        std::cout << "  Num physical groups: " << num_groups << std::endl;
+        if (num_groups > 0) {
+            std::cout << "    ";
+            for (size_t i = 0; i < num_groups; i++) {
+                std::cout << surface.physical_group_tags[i] << " ";
+            }
+            std::cout << std::endl;
+        }
+        size_t num_bounds = surface.boundary_curve_tags.size();
+        std::cout << "  Num boundary curves: " << num_bounds << std::endl;
+        if (num_bounds > 0) {
+            std::cout << "    ";
+            for (size_t i = 0; i < num_bounds; i++) {
+                std::cout << surface.boundary_curve_tags[i] << " ";
+            }
+            std::cout << std::endl;
+        }
+    }
+
+    std::cout << "Num volume entities: " << spec.entities.volumes.size() << std::endl;
+    for (const auto& volume: spec.entities.volumes) {
+        std::cout << "  entity tag: " << volume.tag << std::endl;
+        std::cout << "  bounding box min: " << volume.min_x <<
+            " " << volume.min_y << " " << volume.min_z << std::endl;
+        std::cout << "  bounding box max: " << volume.max_x <<
+            " " << volume.max_y << " " << volume.max_z << std::endl;
+        size_t num_groups = volume.physical_group_tags.size();
+        std::cout << "  Num physical groups: " << num_groups << std::endl;
+        if (num_groups > 0) {
+            std::cout << "    ";
+            for (size_t i = 0; i < num_groups; i++) {
+                std::cout << volume.physical_group_tags[i] << " ";
+            }
+            std::cout << std::endl;
+        }
+        size_t num_bounds = volume.boundary_surface_tags.size();
+        std::cout << "  Num boundary surfaces: " << num_bounds << std::endl;
+        if (num_bounds > 0) {
+            std::cout << "    ";
+            for (size_t i = 0; i < num_bounds; i++) {
+                std::cout << volume.boundary_surface_tags[i] << " ";
+            }
+            std::cout << std::endl;
+        }
+    }
+
     std::cout << "Num physical groups: " << spec.physical_groups.size() << std::endl;
     for (const auto& group: spec.physical_groups) {
         std::cout << "  group dim: " << group.dim << std::endl;

--- a/include/MshIO/MshSpec.h
+++ b/include/MshIO/MshSpec.h
@@ -120,6 +120,11 @@ struct Entities {
     std::vector<CurveEntity> curves;
     std::vector<SurfaceEntity> surfaces;
     std::vector<VolumeEntity> volumes;
+
+    bool empty() const {
+        return points.size() == 0 && curves.size() == 0 && surfaces.size() == 0
+            || volumes.size() == 0;
+    }
 };
 
 struct PhysicalGroup

--- a/include/MshIO/MshSpec.h
+++ b/include/MshIO/MshSpec.h
@@ -71,6 +71,57 @@ struct Data
     std::vector<DataEntry> entries;
 };
 
+struct PointEntity {
+    int tag = 0;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    std::vector<int> physical_group_tags;
+};
+
+struct CurveEntity {
+    int tag = 0;
+    double min_x = 0.0;
+    double min_y = 0.0;
+    double min_z = 0.0;
+    double max_x = 0.0;
+    double max_y = 0.0;
+    double max_z = 0.0;
+    std::vector<int> physical_group_tags;
+    std::vector<int> boundary_point_tags;
+};
+
+struct SurfaceEntity {
+    int tag = 0;
+    double min_x = 0.0;
+    double min_y = 0.0;
+    double min_z = 0.0;
+    double max_x = 0.0;
+    double max_y = 0.0;
+    double max_z = 0.0;
+    std::vector<int> physical_group_tags;
+    std::vector<int> boundary_curve_tags;
+};
+
+struct VolumeEntity {
+    int tag = 0;
+    double min_x = 0.0;
+    double min_y = 0.0;
+    double min_z = 0.0;
+    double max_x = 0.0;
+    double max_y = 0.0;
+    double max_z = 0.0;
+    std::vector<int> physical_group_tags;
+    std::vector<int> boundary_surface_tags;
+};
+
+struct Entities {
+    std::vector<PointEntity> points;
+    std::vector<CurveEntity> curves;
+    std::vector<SurfaceEntity> surfaces;
+    std::vector<VolumeEntity> volumes;
+};
+
 struct PhysicalGroup
 {
     int dim = 0;
@@ -83,6 +134,7 @@ struct MshSpec
     MeshFormat mesh_format;
     Nodes nodes;
     Elements elements;
+    Entities entities;
     std::vector<PhysicalGroup> physical_groups;
     std::vector<Data> node_data;
     std::vector<Data> element_data;

--- a/src/load_msh.cpp
+++ b/src/load_msh.cpp
@@ -3,6 +3,7 @@
 #include "load_msh_curves.h"
 #include "load_msh_data.h"
 #include "load_msh_elements.h"
+#include "load_msh_entities.h"
 #include "load_msh_format.h"
 #include "load_msh_nanospline_format.h"
 #include "load_msh_nodes.h"
@@ -37,6 +38,8 @@ MshSpec load_msh(std::istream& in)
         end_str = "$End" + buf.substr(1);
         if (buf == "$MeshFormat") {
             load_mesh_format(in, spec);
+        } else if (buf == "$Entities") {
+            load_entities(in, spec);
         } else if (buf == "$PhysicalNames") {
             load_physical_groups(in, spec);
         } else if (buf == "$Nodes") {

--- a/src/load_msh_entities.cpp
+++ b/src/load_msh_entities.cpp
@@ -1,0 +1,247 @@
+#include "io_utils.h"
+
+#include <MshIO/MshSpec.h>
+#include <MshIO/exception.h>
+
+#include <cassert>
+#include <fstream>
+
+namespace mshio {
+
+namespace v41 {
+
+void load_entities_ascii(std::istream& in, MshSpec& spec)
+{
+    size_t num_points, num_curves, num_surfaces, num_volumes;
+    in >> num_points;
+    in >> num_curves;
+    in >> num_surfaces;
+    in >> num_volumes;
+    assert(in.good());
+
+    Entities& entities = spec.entities;
+    entities.points.resize(num_points);
+    entities.curves.resize(num_curves);
+    entities.surfaces.resize(num_surfaces);
+    entities.volumes.resize(num_volumes);
+
+    for (size_t i = 0; i < num_points; i++) {
+        PointEntity& point = entities.points[i];
+        in >> point.tag;
+        in >> point.x;
+        in >> point.y;
+        in >> point.z;
+        size_t num_physical_groups;
+        in >> num_physical_groups;
+        point.physical_group_tags.resize(num_physical_groups);
+        for (size_t j = 0; j < num_physical_groups; j++) {
+            in >> point.physical_group_tags[j];
+        }
+    }
+
+    for (size_t i = 0; i < num_curves; i++) {
+        CurveEntity& curve = entities.curves[i];
+        in >> curve.tag;
+        in >> curve.min_x;
+        in >> curve.min_y;
+        in >> curve.min_z;
+        in >> curve.max_x;
+        in >> curve.max_y;
+        in >> curve.max_z;
+        size_t num_physical_groups;
+        in >> num_physical_groups;
+        curve.physical_group_tags.resize(num_physical_groups);
+        for (size_t j = 0; j < num_physical_groups; j++) {
+            in >> curve.physical_group_tags[j];
+        }
+        size_t num_boundary_points;
+        in >> num_boundary_points;
+        curve.boundary_point_tags.resize(num_boundary_points);
+        for (size_t j = 0; j < num_boundary_points; j++) {
+            in >> curve.boundary_point_tags[j];
+        }
+    }
+
+    for (size_t i = 0; i < num_surfaces; i++) {
+        SurfaceEntity& surface = entities.surfaces[i];
+        in >> surface.tag;
+        in >> surface.min_x;
+        in >> surface.min_y;
+        in >> surface.min_z;
+        in >> surface.max_x;
+        in >> surface.max_y;
+        in >> surface.max_z;
+        size_t num_physical_groups;
+        in >> num_physical_groups;
+        surface.physical_group_tags.resize(num_physical_groups);
+        for (size_t j = 0; j < num_physical_groups; j++) {
+            in >> surface.physical_group_tags[j];
+        }
+        size_t num_boundary_curves;
+        in >> num_boundary_curves;
+        surface.boundary_curve_tags.resize(num_boundary_curves);
+        for (size_t j = 0; j < num_boundary_curves; j++) {
+            in >> surface.boundary_curve_tags[j];
+        }
+    }
+
+    for (size_t i = 0; i < num_volumes; i++) {
+        VolumeEntity& volume = entities.volumes[i];
+        in >> volume.tag;
+        in >> volume.min_x;
+        in >> volume.min_y;
+        in >> volume.min_z;
+        in >> volume.max_x;
+        in >> volume.max_y;
+        in >> volume.max_z;
+        size_t num_physical_groups;
+        in >> num_physical_groups;
+        volume.physical_group_tags.resize(num_physical_groups);
+        for (size_t j = 0; j < num_physical_groups; j++) {
+            in >> volume.physical_group_tags[j];
+        }
+        size_t num_boundary_surfaces;
+        in >> num_boundary_surfaces;
+        volume.boundary_surface_tags.resize(num_boundary_surfaces);
+        for (size_t j = 0; j < num_boundary_surfaces; j++) {
+            in >> volume.boundary_surface_tags[j];
+        }
+    }
+
+    assert(in.good());
+}
+
+void load_entities_binary(std::istream& in, MshSpec& spec)
+{
+    eat_white_space(in);
+    size_t num_points, num_curves, num_surfaces, num_volumes;
+    in.read(reinterpret_cast<char*>(&num_points), sizeof(size_t));
+    in.read(reinterpret_cast<char*>(&num_curves), sizeof(size_t));
+    in.read(reinterpret_cast<char*>(&num_surfaces), sizeof(size_t));
+    in.read(reinterpret_cast<char*>(&num_volumes), sizeof(size_t));
+    assert(in.good());
+
+    Entities& entities = spec.entities;
+    entities.points.resize(num_points);
+    entities.curves.resize(num_curves);
+    entities.surfaces.resize(num_surfaces);
+    entities.volumes.resize(num_volumes);
+
+    for (size_t i = 0; i < num_points; i++) {
+        PointEntity& point = entities.points[i];
+        in.read(reinterpret_cast<char*>(&point.tag), sizeof(int));
+        in.read(reinterpret_cast<char*>(&point.x), sizeof(double));
+        in.read(reinterpret_cast<char*>(&point.y), sizeof(double));
+        in.read(reinterpret_cast<char*>(&point.z), sizeof(double));
+        size_t num_physical_groups;
+        in.read(reinterpret_cast<char*>(&num_physical_groups), sizeof(size_t));
+        assert(in.good());
+
+        point.physical_group_tags.resize(num_physical_groups);
+        in.read(reinterpret_cast<char*>(point.physical_group_tags.data()),
+            static_cast<std::streamsize>(sizeof(int) * num_physical_groups));
+        assert(in.good());
+    }
+
+    for (size_t i = 0; i < num_curves; i++) {
+        CurveEntity& curve = entities.curves[i];
+        in.read(reinterpret_cast<char*>(&curve.tag), sizeof(int));
+        in.read(reinterpret_cast<char*>(&curve.min_x), sizeof(double));
+        in.read(reinterpret_cast<char*>(&curve.min_y), sizeof(double));
+        in.read(reinterpret_cast<char*>(&curve.min_z), sizeof(double));
+        in.read(reinterpret_cast<char*>(&curve.max_x), sizeof(double));
+        in.read(reinterpret_cast<char*>(&curve.max_y), sizeof(double));
+        in.read(reinterpret_cast<char*>(&curve.max_z), sizeof(double));
+        size_t num_physical_groups;
+        in.read(reinterpret_cast<char*>(&num_physical_groups), sizeof(size_t));
+        assert(in.good());
+
+        curve.physical_group_tags.resize(num_physical_groups);
+        in.read(reinterpret_cast<char*>(curve.physical_group_tags.data()),
+            static_cast<std::streamsize>(sizeof(int) * num_physical_groups));
+        assert(in.good());
+
+        size_t num_boundary_points;
+        in.read(reinterpret_cast<char*>(&num_boundary_points), sizeof(size_t));
+        assert(in.good());
+
+        curve.boundary_point_tags.resize(num_boundary_points);
+        in.read(reinterpret_cast<char*>(curve.boundary_point_tags.data()),
+            static_cast<std::streamsize>(sizeof(int) * num_boundary_points));
+        assert(in.good());
+    }
+
+    for (size_t i = 0; i < num_surfaces; i++) {
+        SurfaceEntity& surface = entities.surfaces[i];
+        in.read(reinterpret_cast<char*>(&surface.tag), sizeof(int));
+        in.read(reinterpret_cast<char*>(&surface.min_x), sizeof(double));
+        in.read(reinterpret_cast<char*>(&surface.min_y), sizeof(double));
+        in.read(reinterpret_cast<char*>(&surface.min_z), sizeof(double));
+        in.read(reinterpret_cast<char*>(&surface.max_x), sizeof(double));
+        in.read(reinterpret_cast<char*>(&surface.max_y), sizeof(double));
+        in.read(reinterpret_cast<char*>(&surface.max_z), sizeof(double));
+        size_t num_physical_groups;
+        in.read(reinterpret_cast<char*>(&num_physical_groups), sizeof(size_t));
+        assert(in.good());
+
+        surface.physical_group_tags.resize(num_physical_groups);
+        in.read(reinterpret_cast<char*>(surface.physical_group_tags.data()),
+            static_cast<std::streamsize>(sizeof(int) * num_physical_groups));
+        assert(in.good());
+
+        size_t num_boundary_curves;
+        in.read(reinterpret_cast<char*>(&num_boundary_curves), sizeof(size_t));
+        assert(in.good());
+
+        surface.boundary_curve_tags.resize(num_boundary_curves);
+        in.read(reinterpret_cast<char*>(surface.boundary_curve_tags.data()),
+            static_cast<std::streamsize>(sizeof(int) * num_boundary_curves));
+        assert(in.good());
+    }
+
+    for (size_t i = 0; i < num_volumes; i++) {
+        VolumeEntity& volume = entities.volumes[i];
+        in.read(reinterpret_cast<char*>(&volume.tag), sizeof(int));
+        in.read(reinterpret_cast<char*>(&volume.min_x), sizeof(double));
+        in.read(reinterpret_cast<char*>(&volume.min_y), sizeof(double));
+        in.read(reinterpret_cast<char*>(&volume.min_z), sizeof(double));
+        in.read(reinterpret_cast<char*>(&volume.max_x), sizeof(double));
+        in.read(reinterpret_cast<char*>(&volume.max_y), sizeof(double));
+        in.read(reinterpret_cast<char*>(&volume.max_z), sizeof(double));
+        size_t num_physical_groups;
+        in.read(reinterpret_cast<char*>(&num_physical_groups), sizeof(size_t));
+        assert(in.good());
+
+        volume.physical_group_tags.resize(num_physical_groups);
+        in.read(reinterpret_cast<char*>(volume.physical_group_tags.data()),
+            static_cast<std::streamsize>(sizeof(int) * num_physical_groups));
+        assert(in.good());
+
+        size_t num_boundary_surfaces;
+        in.read(reinterpret_cast<char*>(&num_boundary_surfaces), sizeof(size_t));
+        assert(in.good());
+
+        volume.boundary_surface_tags.resize(num_boundary_surfaces);
+        in.read(reinterpret_cast<char*>(volume.boundary_surface_tags.data()),
+            static_cast<std::streamsize>(sizeof(int) * num_boundary_surfaces));
+        assert(in.good());
+    }
+}
+
+} // namespace v41
+
+void load_entities(std::istream& in, MshSpec& spec)
+{
+    const std::string& version = spec.mesh_format.version;
+    const bool is_ascii = spec.mesh_format.file_type == 0;
+    if (version == "4.1") {
+        if (is_ascii)
+            v41::load_entities_ascii(in, spec);
+        else
+            v41::load_entities_binary(in, spec);
+    } else if (version == "2.2") {
+        throw InvalidFormat("$Entities section not supported by MSH version 2.2");
+    }
+}
+
+} // namespace mshio

--- a/src/load_msh_entities.h
+++ b/src/load_msh_entities.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <MshIO/MshSpec.h>
+#include <iostream>
+
+namespace mshio {
+
+void load_entities(std::istream& in, MshSpec& spec);
+
+}

--- a/src/save_msh.cpp
+++ b/src/save_msh.cpp
@@ -3,6 +3,7 @@
 #include "save_msh_curves.h"
 #include "save_msh_data.h"
 #include "save_msh_elements.h"
+#include "save_msh_entities.h"
 #include "save_msh_format.h"
 #include "save_msh_nodes.h"
 #include "save_msh_patches.h"
@@ -19,6 +20,9 @@ void save_msh(std::ostream& out, const MshSpec& spec)
     save_mesh_format(out, spec);
     if (spec.physical_groups.size() > 0) {
         save_physical_groups(out, spec);
+    }
+    if (!spec.entities.empty()) {
+        save_entities(out, spec);
     }
     if (spec.nodes.num_nodes > 0) {
         save_nodes(out, spec);

--- a/src/save_msh_entities.cpp
+++ b/src/save_msh_entities.cpp
@@ -1,0 +1,184 @@
+#include "save_msh_entities.h"
+
+#include <MshIO/MshSpec.h>
+#include <MshIO/exception.h>
+
+#include <algorithm>
+#include <cassert>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace mshio {
+
+namespace v41 {
+
+void save_entities_ascii(std::ostream& out, const MshSpec& spec)
+{
+    const Entities& entities = spec.entities;
+    out << entities.points.size() << " " << entities.curves.size() << " "
+        << entities.surfaces.size() << " " << entities.volumes.size() << std::endl;
+
+    for (size_t i = 0; i < entities.points.size(); i++) {
+        const PointEntity& point = entities.points[i];
+        out << point.tag << " " << point.x << " " << point.y << " " << point.z
+            << " " << point.physical_group_tags.size();
+        for (size_t j = 0; j < point.physical_group_tags.size(); j++) {
+            out << " " << point.physical_group_tags[j];
+        }
+        out << std::endl;
+    }
+
+    for (size_t i = 0; i < entities.curves.size(); i++) {
+        const CurveEntity& curve = entities.curves[i];
+        out << curve.tag << " " << curve.min_x << " " << curve.min_y << " "
+            << curve.min_z << " " << curve.max_x << " " << curve.max_y << " "
+            << curve.max_z << " " << curve.physical_group_tags.size();
+        for (size_t j = 0; j < curve.physical_group_tags.size(); j++) {
+            out << " " << curve.physical_group_tags[j];
+        }
+        out << " " << curve.boundary_point_tags.size();
+        for (size_t j = 0; j < curve.boundary_point_tags.size(); j++) {
+            out << " " << curve.boundary_point_tags[j];
+        }
+        out << std::endl;
+    }
+
+    for (size_t i = 0; i < entities.surfaces.size(); i++) {
+        const SurfaceEntity& surface = entities.surfaces[i];
+        out << surface.tag << " " << surface.min_x << " " << surface.min_y << " "
+            << surface.min_z << " " << surface.max_x << " " << surface.max_y << " "
+            << surface.max_z << " " << surface.physical_group_tags.size();
+        for (size_t j = 0; j < surface.physical_group_tags.size(); j++) {
+            out << " " << surface.physical_group_tags[j];
+        }
+        out << " " << surface.boundary_curve_tags.size();
+        for (size_t j = 0; j < surface.boundary_curve_tags.size(); j++) {
+            out << " " << surface.boundary_curve_tags[j];
+        }
+        out << std::endl;
+    }
+
+    for (size_t i = 0; i < entities.volumes.size(); i++) {
+        const VolumeEntity& volume = entities.volumes[i];
+        out << volume.tag << " " << volume.min_x << " " << volume.min_y << " "
+            << volume.min_z << " " << volume.max_x << " " << volume.max_y << " "
+            << volume.max_z << " " << volume.physical_group_tags.size();
+        for (size_t j = 0; j < volume.physical_group_tags.size(); j++) {
+            out << " " << volume.physical_group_tags[j];
+        }
+        out << " " << volume.boundary_surface_tags.size();
+        for (size_t j = 0; j < volume.boundary_surface_tags.size(); j++) {
+            out << " " << volume.boundary_surface_tags[j];
+        }
+        out << std::endl;
+    }
+}
+
+void save_entities_binary(std::ostream& out, const MshSpec& spec)
+{
+    const Entities& entities = spec.entities;
+    size_t num_points = entities.points.size();
+    size_t num_curves = entities.curves.size();
+    size_t num_surfaces = entities.surfaces.size();
+    size_t num_volumes = entities.volumes.size();
+    out.write(reinterpret_cast<const char*>(&num_points), sizeof(size_t));
+    out.write(reinterpret_cast<const char*>(&num_curves), sizeof(size_t));
+    out.write(reinterpret_cast<const char*>(&num_surfaces), sizeof(size_t));
+    out.write(reinterpret_cast<const char*>(&num_volumes), sizeof(size_t));
+
+    for (size_t i = 0; i < num_points; i++) {
+        const PointEntity& point = entities.points[i];
+        out.write(reinterpret_cast<const char*>(&point.tag), sizeof(int));
+        out.write(reinterpret_cast<const char*>(&point.x), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&point.y), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&point.z), sizeof(double));
+        size_t num_physical_groups = point.physical_group_tags.size();
+        out.write(reinterpret_cast<const char*>(&num_physical_groups), sizeof(size_t));
+        out.write(reinterpret_cast<const char*>(point.physical_group_tags.data()),
+            static_cast<std::streamsize>(sizeof(size_t) * num_physical_groups));
+    }
+
+    for (size_t i = 0; i < num_curves; i++) {
+        const CurveEntity& curve = entities.curves[i];
+        out.write(reinterpret_cast<const char*>(&curve.tag), sizeof(int));
+        out.write(reinterpret_cast<const char*>(&curve.min_x), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&curve.min_y), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&curve.min_z), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&curve.max_x), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&curve.max_y), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&curve.max_z), sizeof(double));
+        size_t num_physical_groups = curve.physical_group_tags.size();
+        out.write(reinterpret_cast<const char*>(&num_physical_groups), sizeof(size_t));
+        out.write(reinterpret_cast<const char*>(curve.physical_group_tags.data()),
+            static_cast<std::streamsize>(sizeof(size_t) * num_physical_groups));
+        size_t num_boundary_points = curve.boundary_point_tags.size();
+        out.write(reinterpret_cast<const char*>(&num_boundary_points), sizeof(size_t));
+        out.write(reinterpret_cast<const char*>(curve.boundary_point_tags.data()),
+            static_cast<std::streamsize>(sizeof(size_t) * num_boundary_points));
+    }
+
+    for (size_t i = 0; i < num_surfaces; i++) {
+        const SurfaceEntity& surface = entities.surfaces[i];
+        out.write(reinterpret_cast<const char*>(&surface.tag), sizeof(int));
+        out.write(reinterpret_cast<const char*>(&surface.min_x), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&surface.min_y), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&surface.min_z), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&surface.max_x), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&surface.max_y), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&surface.max_z), sizeof(double));
+        size_t num_physical_groups = surface.physical_group_tags.size();
+        out.write(reinterpret_cast<const char*>(&num_physical_groups), sizeof(size_t));
+        out.write(reinterpret_cast<const char*>(surface.physical_group_tags.data()),
+            static_cast<std::streamsize>(sizeof(size_t) * num_physical_groups));
+        size_t num_boundary_curves = surface.boundary_curve_tags.size();
+        out.write(reinterpret_cast<const char*>(&num_boundary_curves), sizeof(size_t));
+        out.write(reinterpret_cast<const char*>(surface.boundary_curve_tags.data()),
+            static_cast<std::streamsize>(sizeof(size_t) * num_boundary_curves));
+    }
+
+    for (size_t i = 0; i < num_volumes; i++) {
+        const VolumeEntity& volume = entities.volumes[i];
+        out.write(reinterpret_cast<const char*>(&volume.tag), sizeof(int));
+        out.write(reinterpret_cast<const char*>(&volume.min_x), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&volume.min_y), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&volume.min_z), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&volume.max_x), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&volume.max_y), sizeof(double));
+        out.write(reinterpret_cast<const char*>(&volume.max_z), sizeof(double));
+        size_t num_physical_groups = volume.physical_group_tags.size();
+        out.write(reinterpret_cast<const char*>(&num_physical_groups), sizeof(size_t));
+        out.write(reinterpret_cast<const char*>(volume.physical_group_tags.data()),
+            static_cast<std::streamsize>(sizeof(size_t) * num_physical_groups));
+        size_t num_boundary_surfaces = volume.boundary_surface_tags.size();
+        out.write(reinterpret_cast<const char*>(&num_boundary_surfaces), sizeof(size_t));
+        out.write(reinterpret_cast<const char*>(volume.boundary_surface_tags.data()),
+            static_cast<std::streamsize>(sizeof(size_t) * num_boundary_surfaces));
+    }
+}
+
+} // namespace v41
+
+void save_entities(std::ostream& out, const MshSpec& spec)
+{
+    const std::string& version = spec.mesh_format.version;
+    const bool is_ascii = spec.mesh_format.file_type == 0;
+    if (version == "2.2") {
+        // version 2.2 has no $Entities section
+        return;
+    }
+    out << "$Entities" << std::endl;
+    if (version == "4.1") {
+        if (is_ascii)
+            v41::save_entities_ascii(out, spec);
+        else
+            v41::save_entities_binary(out, spec);
+    } else {
+        std::stringstream msg;
+        msg << "Unsupported MSH version: " << version;
+        throw UnsupportedFeature(msg.str());
+    }
+    out << "$EndEntities" << std::endl;
+}
+
+} // namespace mshio

--- a/src/save_msh_entities.h
+++ b/src/save_msh_entities.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <MshIO/MshSpec.h>
+#include <iostream>
+
+namespace mshio {
+
+void save_entities(std::ostream& out, const MshSpec& spec);
+
+} // namespace mshio


### PR DESCRIPTION
Add support for saving and loading the msh 4.1 `$Entities` section. The diff is pretty large, because of the nearly identical `CurveEntity`, `SurfaceEntity` and `VolumeEntity` structs and their corresponding sections. There are probably some options to reduce duplication, but I thought I might as well keep it simple for the first pass. If you would like any changes please let me know. I have been testing as I go, but I would like to add some tests as well.

Here is the `msh_inspect` output for this `$Entities` section:
```text
$Entities
1 1 2 1
1 1 2 3 2 1 2
1 -10 -20 -30 10 20 30 2 1 2 1 1
1 -10 -20 -30 10 20 30 2 1 2 1 1
2 10 20 30 -10 -20 -30 3 1 2 3 1 1
1 0 0 0 0 0 0 1 1 2 1 2
$EndEntities
```
```text
Num point entities: 1
  entity tag: 1
  entity coordinates: 1 2 3
  Num physical groups: 2
    1 2
Num curve entities: 1
  entity tag: 1
  bounding box min: -10 -20 -30
  bounding box max: 10 20 30
  Num physical groups: 2
    1 2
  Num boundary points: 1
    1
Num surface entities: 2
  entity tag: 1
  bounding box min: -10 -20 -30
  bounding box max: 10 20 30
  Num physical groups: 2
    1 2
  Num boundary curves: 1
    1
  entity tag: 2
  bounding box min: 10 20 30
  bounding box max: -10 -20 -30
  Num physical groups: 3
    1 2 3
  Num boundary curves: 1
    1
Num volume entities: 1
  entity tag: 1
  bounding box min: 0 0 0
  bounding box max: 0 0 0
  Num physical groups: 1
    1
  Num boundary surfaces: 2
    1 2
```