### PR TITLE
Fix bug in Entities.is_empty()

### DIFF
--- a/include/MshIO/MshSpec.h
+++ b/include/MshIO/MshSpec.h
@@ -123,7 +123,7 @@ struct Entities {
 
     bool empty() const {
         return points.size() == 0 && curves.size() == 0 && surfaces.size() == 0
-            || volumes.size() == 0;
+            && volumes.size() == 0;
     }
 };
 


### PR DESCRIPTION
Fix operator typo introduced in  https://github.com/qnzhou/MshIO/pull/5 and caught by the mighty clang: https://github.com/qnzhou/MshIO/runs/2005468693

Sorry about that, it was left over from when the method was called `non_empty`.