### PR TITLE
Add <limits> STL header

### DIFF
--- a/src/load_msh_elements.cpp
+++ b/src/load_msh_elements.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <limits>
 
 
 namespace mshio {

--- a/src/load_msh_nodes.cpp
+++ b/src/load_msh_nodes.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <limits>
 
 namespace mshio {
 namespace v41 {


### PR DESCRIPTION
The library didn't compile without the added header declarations in GCC 11.1.0 (C++17 standard).