### PR TITLE
Enable loading of element tags from 2.2 binary format

### DIFF
--- a/src/load_msh_post_process.cpp
+++ b/src/load_msh_post_process.cpp
@@ -106,9 +106,7 @@ void load_msh_post_process(MshSpec& spec)
 {
     if (spec.mesh_format.version == "2.2") {
         v22::regroup_nodes_into_blocks(spec);
-        if (spec.mesh_format.file_type == 0) {
-            v22::regroup_elements_into_blocks(spec);
-        }
+        v22::regroup_elements_into_blocks(spec);
     }
 }
 


### PR DESCRIPTION
The element tags in the binary 2.2 format were ignored, so I reordered the function so it can keep the tag even if they differ within an element block. The function is very similar to loading the ASCII 2.2 format (one element block per element with elements being regrouped in the post-process).

I tested this on the same mesh in both ASCII and binary format, and now the output of `msh_inspect` is identical.