### PR TITLE
Update catch2.

### DIFF
--- a/cmake/Catch2.cmake
+++ b/cmake/Catch2.cmake
@@ -4,7 +4,7 @@ if (NOT TARGET Catch2::Catch2)
     FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG        v2.11.3
+        GIT_TAG        v2.13.9
         GIT_SHALLOW TRUE
     )
 


### PR DESCRIPTION
Summary:
* Update catch2 to the newest release to avoid [compilation issue](https://github.com/exercism/cpp/issues/432) on M1.