### PR TITLE
Using nanobind tensor for python binding

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -28,4 +28,4 @@ jobs:
            pip install --verbose .
 
     - name: Test
-      run: python -m pytest
+      run: python -m pytest tests

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -1,0 +1,31 @@
+name: "Pip"
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+
+jobs:
+  build:
+    name: Build with Pip
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-latest]
+        python-version: ["3.8", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Build and install
+      run: python -m pip install pytest
+           pip install --verbose .
+
+    - name: Test
+      run: python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 build*/
 _skbuild/
 *.egg-info/
+__pycache__
+env/
+*.so
+*.msh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(mshio STATIC ${SRC_FILES})
 target_include_directories(mshio PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>")
+set_property(TARGET mshio PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_library(mshio::mshio ALIAS mshio)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,16 @@ if (MSHIO_PYTHON)
     target_link_libraries(pymshio PUBLIC mshio::mshio)
     install(TARGETS pymshio LIBRARY DESTINATION .)
     add_library(mshio::pymshio ALIAS pymshio)
+
+    include(cmake/sanitizer-cmake.cmake)
+    if (SANITIZE_ADDRESS OR
+            SANITIZE_LINK_STATIC OR
+            SANITIZE_MEMORY OR
+            SANITIZE_THREAD OR
+            SANITIZE_UNDEFINED)
+        add_sanitizers(pymshio)
+        target_link_options(pymshio PRIVATE "-shared-libasan")
+    endif()
 endif()
 
 

--- a/cmake/nanobind.cmake
+++ b/cmake/nanobind.cmake
@@ -6,7 +6,7 @@ include(cmake/python.cmake)
 FetchContent_Declare(
     nanobind
     GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-    GIT_TAG 836405b6e2b64ceac42d6bc90081fed0275b800d
+    GIT_TAG 53e88b6cf0764ccc157123e3c0f815d33bb80119
     GIT_SHALLOW OFF)
 
 FetchContent_Populate(nanobind)

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     cmake_install_dir="python/mshio",
     include_package_data=True,
     python_requires=">=3.8",
-    dependencies=[
+    install_requires=[
         "pytest",
-        "numpy>=1.21"
+        "numpy>=1.23"
         ]
 )

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,9 @@ setup(
     package_dir={'': 'python'},
     cmake_install_dir="python/mshio",
     include_package_data=True,
-    python_requires=">=3.8"
+    python_requires=">=3.8",
+    dependencies=[
+        "pytest",
+        "numpy>=1.21"
+        ]
 )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     cmake_install_dir="python/mshio",
     include_package_data=True,
     python_requires=">=3.8",
+    #cmake_args=['-DSANITIZE_ADDRESS=On'],
     install_requires=[
         "pytest",
         "numpy>=1.23"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import mshio
+import numbers
+import pytest
+import logging
+
+class TestNodes:
+    logger = logging.getLogger(__name__)
+
+    def test_node_block(self):
+        block = mshio.NodeBlock()
+        assert isinstance(block.entity_dim, numbers.Number)
+        assert isinstance(block.entity_tag, numbers.Number)
+        assert isinstance(block.parametric, numbers.Number)
+        assert isinstance(block.num_nodes_in_block, numbers.Number)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,9 +4,21 @@ import mshio
 import numbers
 import pytest
 import logging
+import numpy as np
+
 
 class TestNodes:
     logger = logging.getLogger(__name__)
+
+    def generate_tmp(self):
+        block = mshio.NodeBlock()
+        block.tags = np.array([1, 2, 3])
+        return block.tags
+
+    def test_tmp(self):
+        tags = self.generate_tmp()
+        assert len(tags) == 3
+        assert tags[0] == 1
 
     def test_node_block(self):
         block = mshio.NodeBlock()
@@ -14,3 +26,30 @@ class TestNodes:
         assert isinstance(block.entity_tag, numbers.Number)
         assert isinstance(block.parametric, numbers.Number)
         assert isinstance(block.num_nodes_in_block, numbers.Number)
+        assert isinstance(block.tags, np.ndarray)
+        assert isinstance(block.data, np.ndarray)
+
+        assert len(block.tags) == 0
+        tags = np.array([1, 2, 3])
+        block.tags = tags
+        assert len(block.tags) == 3
+        assert len(block._tags_) == 3
+        assert np.all(block.tags == tags)
+
+        assert len(block.data) == 0
+        vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+        block.data = vertices
+        assert len(block.data) == 3
+        assert np.all(block.data == vertices)
+
+    def test_element_block(self):
+        block = mshio.ElementBlock()
+        facets = np.array([
+            [1, 0, 1, 2],
+            [2, 2, 1, 3]
+            ])
+        block.data = facets
+
+        assert len(block.data) == 2
+        assert block.data.shape[1] == 4
+        assert np.all(block.data == facets)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,6 +19,9 @@ class TestNodes:
         tags = self.generate_tmp()
         assert len(tags) == 3
         assert tags[0] == 1
+        tags.setflags(write=True)
+        tags[0] = -1
+        assert tags[0] == -1
 
     def test_node_block(self):
         block = mshio.NodeBlock()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,9 +19,9 @@ class TestNodes:
         tags = self.generate_tmp()
         assert len(tags) == 3
         assert tags[0] == 1
-        tags.setflags(write=True)
-        tags[0] = -1
-        assert tags[0] == -1
+
+        with pytest.raises(ValueError) as e:
+            tags.setflags(write=True)
 
     def test_node_block(self):
         block = mshio.NodeBlock()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py39
+isolated_build = True
+
+[testenv]
+deps = pytest
+commands = pytest -s tests


### PR DESCRIPTION
Summary:
* Expose `NodeBlock::data` and `ElementBlock::data` in python via nanobind tensor for readonly access.  Due to limitation of numpy's dlpack policy, the exposed array is readonly, so no local update is allowed.  Global update is still possible, but it will involve a write operation.
* Move the old python binding to `_data_`.