### PR TITLE
Refactor `mshio::Data`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT MSVC)
     target_compile_options(mshio PRIVATE -Wconversion -Wall -Werror
         -Wno-deprecated-declarations)
 else()
-    target_compile_options(mshio PRIVATE "/wd4996")
+    target_compile_options(mshio PRIVATE /wd4996)
 endif()
 target_include_directories(mshio PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -55,7 +55,7 @@ if (MSHIO_PYTHON)
     if (NOT MSVC)
         target_compile_options(pymshio PRIVATE -Wno-deprecated-declarations)
     else()
-        target_compile_options(pymshio PRIVATE "/wd4996")
+        target_compile_options(pymshio PRIVATE /wd4996)
     endif()
     target_link_libraries(pymshio PUBLIC mshio::mshio)
     install(TARGETS pymshio LIBRARY DESTINATION .)
@@ -79,7 +79,7 @@ if (MSHIO_BUILD_EXAMPLES)
     if (NOT MSVC)
         target_compile_options(msh_inspect PRIVATE -Wno-deprecated-declarations)
     else()
-        target_compile_options(msh_inspect PRIVATE "/wd4996")
+        target_compile_options(msh_inspect PRIVATE /wd4996)
     endif()
 endif()
 
@@ -101,7 +101,7 @@ if (MSHIO_BUILD_TESTS)
         target_compile_options(test_MshIO PRIVATE -Wconversion -Wall -Werror
             -Wno-deprecated-declarations)
     else()
-        target_compile_options(test_MshIO PRIVATE "/MP /wd4996")
+        target_compile_options(test_MshIO PRIVATE /MP /wd4996)
     endif()
 
     if (SANITIZE_ADDRESS OR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,10 @@ file(GLOB INC_FILES "${PROJECT_SOURCE_DIR}/include/mshio/*.h")
 file(GLOB SRC_FILES "${PROJECT_SOURCE_DIR}/src/*.cpp")
 
 add_library(mshio STATIC ${SRC_FILES})
-target_compile_options(mshio PRIVATE -Wconversion -Wall -Werror
-    -Wno-deprecated-declarations)
+if(NOT MSVC)
+    target_compile_options(mshio PRIVATE -Wconversion -Wall -Werror
+        -Wno-deprecated-declarations)
+endif()
 target_include_directories(mshio PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>")
@@ -48,7 +50,9 @@ if (MSHIO_PYTHON)
     include(cmake/nanobind.cmake)
     set(PY_SRC_FILE "${PROJECT_SOURCE_DIR}/python/pymshio.cpp")
     nanobind_add_module(pymshio NB_STATIC ${PY_SRC_FILE})
-    target_compile_options(pymshio PRIVATE -Wno-deprecated-declarations)
+    if (NOT MSVC)
+        target_compile_options(pymshio PRIVATE -Wno-deprecated-declarations)
+    endif()
     target_link_libraries(pymshio PUBLIC mshio::mshio)
     install(TARGETS pymshio LIBRARY DESTINATION .)
     add_library(mshio::pymshio ALIAS pymshio)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ file(GLOB INC_FILES "${PROJECT_SOURCE_DIR}/include/mshio/*.h")
 file(GLOB SRC_FILES "${PROJECT_SOURCE_DIR}/src/*.cpp")
 
 add_library(mshio STATIC ${SRC_FILES})
+target_compile_options(mshio PRIVATE -Wconversion -Wall -Werror
+    -Wno-deprecated-declarations)
 target_include_directories(mshio PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>")
@@ -46,6 +48,7 @@ if (MSHIO_PYTHON)
     include(cmake/nanobind.cmake)
     set(PY_SRC_FILE "${PROJECT_SOURCE_DIR}/python/pymshio.cpp")
     nanobind_add_module(pymshio NB_STATIC ${PY_SRC_FILE})
+    target_compile_options(pymshio PRIVATE -Wno-deprecated-declarations)
     target_link_libraries(pymshio PUBLIC mshio::mshio)
     install(TARGETS pymshio LIBRARY DESTINATION .)
     add_library(mshio::pymshio ALIAS pymshio)
@@ -65,6 +68,7 @@ endif()
 if (MSHIO_BUILD_EXAMPLES)
     add_executable(msh_inspect ${PROJECT_SOURCE_DIR}/examples/msh_inspect.cpp)
     target_link_libraries(msh_inspect PRIVATE mshio::mshio)
+    target_compile_options(msh_inspect PRIVATE -Wno-deprecated-declarations)
 endif()
 
 
@@ -82,7 +86,8 @@ if (MSHIO_BUILD_TESTS)
     catch_discover_tests(test_MshIO)
 
     if(NOT MSVC)
-        target_compile_options(test_MshIO PRIVATE -Wconversion -Wall -Werror)
+        target_compile_options(test_MshIO PRIVATE -Wconversion -Wall -Werror
+            -Wno-deprecated-declarations)
     else()
         target_compile_options(test_MshIO PRIVATE "/MP")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(mshio STATIC ${SRC_FILES})
 if(NOT MSVC)
     target_compile_options(mshio PRIVATE -Wconversion -Wall -Werror
         -Wno-deprecated-declarations)
+else()
+    target_compile_options(mshio PRIVATE "/wd4996")
 endif()
 target_include_directories(mshio PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -52,6 +54,8 @@ if (MSHIO_PYTHON)
     nanobind_add_module(pymshio NB_STATIC ${PY_SRC_FILE})
     if (NOT MSVC)
         target_compile_options(pymshio PRIVATE -Wno-deprecated-declarations)
+    else()
+        target_compile_options(pymshio PRIVATE "/wd4996")
     endif()
     target_link_libraries(pymshio PUBLIC mshio::mshio)
     install(TARGETS pymshio LIBRARY DESTINATION .)
@@ -72,7 +76,11 @@ endif()
 if (MSHIO_BUILD_EXAMPLES)
     add_executable(msh_inspect ${PROJECT_SOURCE_DIR}/examples/msh_inspect.cpp)
     target_link_libraries(msh_inspect PRIVATE mshio::mshio)
-    target_compile_options(msh_inspect PRIVATE -Wno-deprecated-declarations)
+    if (NOT MSVC)
+        target_compile_options(msh_inspect PRIVATE -Wno-deprecated-declarations)
+    else()
+        target_compile_options(msh_inspect PRIVATE "/wd4996")
+    endif()
 endif()
 
 
@@ -93,7 +101,7 @@ if (MSHIO_BUILD_TESTS)
         target_compile_options(test_MshIO PRIVATE -Wconversion -Wall -Werror
             -Wno-deprecated-declarations)
     else()
-        target_compile_options(test_MshIO PRIVATE "/MP")
+        target_compile_options(test_MshIO PRIVATE "/MP /wd4996")
     endif()
 
     if (SANITIZE_ADDRESS OR

--- a/examples/msh_inspect.cpp
+++ b/examples/msh_inspect.cpp
@@ -179,13 +179,13 @@ int main(int argc, char** argv)
         }
         std::cout << std::endl;
 
-        size_t fields_per_entity = static_cast<size_t>(data.header.int_tags[1]);
-        size_t num_entities = static_cast<size_t>(data.header.int_tags[2]);
-        for (size_t i = 0; i < num_entities; i++) {
-            const mshio::DataEntry& entry = data.entries[i];
-            std::cout << "  " << entry.tag << ": ";
-            for (size_t j = 0; j < fields_per_entity; j++) {
-                std::cout << entry.data[j] << " ";
+        size_t num_fields = static_cast<size_t>(data.header.int_tags[1]);
+        size_t num_entries = static_cast<size_t>(data.header.int_tags[2]);
+        size_t entry_size = data.nodes_per_element == 0 ? num_fields : num_fields * data.nodes_per_element;
+        for (size_t i=0; i< num_entries; i++) {
+            std::cout << "  " << data.tags[i] << ":";
+            for (size_t j=0; j<entry_size; j++) {
+                std::cout << ' ' << data.data[i*entry_size + j];
             }
             std::cout << std::endl;
         }
@@ -201,6 +201,13 @@ int main(int argc, char** argv)
     if (spec.element_data.size() > 0) {
         std::cout << "Element data: " << std::endl;
         for (const mshio::Data& data : spec.element_data) {
+            print_data(data);
+        }
+    }
+
+    if (spec.element_node_data.size() > 0) {
+        std::cout << "ElementNode data: " << std::endl;
+        for (const mshio::Data& data : spec.element_node_data) {
             print_data(data);
         }
     }

--- a/include/mshio/MshSpec.h
+++ b/include/mshio/MshSpec.h
@@ -58,7 +58,7 @@ struct DataHeader
     std::vector<int> int_tags; // [time step, num fields, num entries, partition id]
 };
 
-struct DataEntry
+struct [[deprecated("Use `Data::tags` and `Data::data` instead")]] DataEntry
 {
     size_t tag = 0;
     int num_nodes_per_element = 0; // Only used by ElementNodeData.
@@ -68,10 +68,15 @@ struct DataEntry
 struct Data
 {
     DataHeader header;
-    std::vector<DataEntry> entries;
+    [[deprecated]] std::vector<DataEntry> entries;
+
+    size_t nodes_per_element = 0; // Only used by ElementNodeData.
+    std::vector<size_t> tags;
+    std::vector<double> data;
 };
 
-struct PointEntity {
+struct PointEntity
+{
     int tag = 0;
     double x = 0.0;
     double y = 0.0;
@@ -79,7 +84,8 @@ struct PointEntity {
     std::vector<int> physical_group_tags;
 };
 
-struct CurveEntity {
+struct CurveEntity
+{
     int tag = 0;
     double min_x = 0.0;
     double min_y = 0.0;
@@ -91,7 +97,8 @@ struct CurveEntity {
     std::vector<int> boundary_point_tags;
 };
 
-struct SurfaceEntity {
+struct SurfaceEntity
+{
     int tag = 0;
     double min_x = 0.0;
     double min_y = 0.0;
@@ -103,7 +110,8 @@ struct SurfaceEntity {
     std::vector<int> boundary_curve_tags;
 };
 
-struct VolumeEntity {
+struct VolumeEntity
+{
     int tag = 0;
     double min_x = 0.0;
     double min_y = 0.0;
@@ -115,15 +123,17 @@ struct VolumeEntity {
     std::vector<int> boundary_surface_tags;
 };
 
-struct Entities {
+struct Entities
+{
     std::vector<PointEntity> points;
     std::vector<CurveEntity> curves;
     std::vector<SurfaceEntity> surfaces;
     std::vector<VolumeEntity> volumes;
 
-    bool empty() const {
-        return points.size() == 0 && curves.size() == 0 && surfaces.size() == 0
-            && volumes.size() == 0;
+    bool empty() const
+    {
+        return points.size() == 0 && curves.size() == 0 && surfaces.size() == 0 &&
+               volumes.size() == 0;
     }
 };
 

--- a/src/load_msh_curves.cpp
+++ b/src/load_msh_curves.cpp
@@ -53,7 +53,8 @@ void load_curves_binary(std::istream& in, MshSpec& spec)
         size_t num_entries =
             curve.num_control_points * ((curve.with_weights > 0) ? 4 : 3) + curve.num_knots;
         curve.data.resize(num_entries);
-        in.read(reinterpret_cast<char*>(curve.data.data()), sizeof(double) * num_entries);
+        in.read(reinterpret_cast<char*>(curve.data.data()),
+            static_cast<std::streamsize>(sizeof(double) * num_entries));
     }
 #endif
 }

--- a/src/load_msh_data.cpp
+++ b/src/load_msh_data.cpp
@@ -38,7 +38,7 @@ void load_data_header(std::istream& in, DataHeader& header)
 }
 
 namespace v41 {
-void load_data_entry(
+[[deprecated]] void load_data_entry(
     std::istream& in, DataEntry& entry, size_t fields_per_entry, bool is_element_node_data)
 {
     // TODO:
@@ -58,10 +58,39 @@ void load_data_entry(
     in.read(reinterpret_cast<char*>(entry.data.data()),
         static_cast<std::streamsize>(sizeof(double) * entry.data.size()));
 }
+
+void load_data_entry(std::istream& in,
+    Data& data,
+    size_t i,
+    size_t num_entries,
+    size_t fields_per_entry,
+    bool is_element_node_data)
+{
+    int32_t tag_32;
+    in.read(reinterpret_cast<char*>(&tag_32), 4);
+    data.tags[i] = static_cast<size_t>(tag_32);
+
+    size_t entry_size = fields_per_entry;
+    if (is_element_node_data) {
+        int32_t nodes_per_element = 0;
+        in.read(reinterpret_cast<char*>(&nodes_per_element), 4);
+        entry_size = static_cast<size_t>(nodes_per_element) * fields_per_entry;
+        if (data.nodes_per_element == 0) {
+            assert(nodes_per_element != 0);
+            data.nodes_per_element = static_cast<size_t>(nodes_per_element);
+            data.data.resize(num_entries * entry_size);
+        } else if (static_cast<size_t>(nodes_per_element) != data.nodes_per_element) {
+            throw InvalidFormat("Hybrid elements not supported in ElementNodeData");
+        }
+    }
+
+    in.read(reinterpret_cast<char*>(data.data.data() + i * entry_size),
+        static_cast<std::streamsize>(sizeof(double) * entry_size));
+}
 } // namespace v41
 
 namespace v22 {
-void load_data_entry(
+[[deprecated]] void load_data_entry(
     std::istream& in, DataEntry& entry, size_t fields_per_entry, bool is_element_node_data)
 {
     int32_t tag_32;
@@ -78,6 +107,18 @@ void load_data_entry(
     in.read(reinterpret_cast<char*>(entry.data.data()),
         static_cast<std::streamsize>(sizeof(double) * entry.data.size()));
 }
+
+void load_data_entry(std::istream& in,
+    Data& data,
+    size_t i,
+    size_t num_entries,
+    size_t fields_per_entry,
+    bool is_element_node_data)
+{
+    // v41 does not introduce new changes.
+    v41::load_data_entry(in, data, i, num_entries, fields_per_entry, is_element_node_data);
+}
+
 } // namespace v22
 
 void load_data(std::istream& in,
@@ -94,42 +135,76 @@ void load_data(std::istream& in,
 
     size_t fields_per_entry = static_cast<size_t>(data.header.int_tags[1]);
     size_t num_entries = static_cast<size_t>(data.header.int_tags[2]);
-    data.entries.resize(num_entries);
+
+    data.tags.resize(num_entries);
+    if (!is_element_node_data) {
+        data.data.resize(num_entries * fields_per_entry);
+    }
 
     if (is_binary) {
         eat_white_space(in, 1);
         if (version == "4.1") {
             for (size_t i = 0; i < num_entries; i++) {
-                v41::load_data_entry(in, data.entries[i], fields_per_entry, is_element_node_data);
+                v41::load_data_entry(
+                    in, data, i, num_entries, fields_per_entry, is_element_node_data);
             }
         } else if (version == "2.2") {
             for (size_t i = 0; i < num_entries; i++) {
-                v22::load_data_entry(in, data.entries[i], fields_per_entry, is_element_node_data);
+                v22::load_data_entry(
+                    in, data, i, num_entries, fields_per_entry, is_element_node_data);
             }
         } else {
             throw InvalidFormat("Unsupported version " + version);
         }
     } else {
-        for (size_t i = 0; i < num_entries; i++) {
-            DataEntry& entry = data.entries[i];
-            in >> entry.tag;
-            if (is_element_node_data) {
-                in >> entry.num_nodes_per_element;
-                entry.data.resize(fields_per_entry * entry.num_nodes_per_element);
-                for (size_t j = 0; j < entry.num_nodes_per_element; j++) {
+        if (is_element_node_data) {
+            auto allocate_memory = [&]() {
+                assert(data.nodes_per_element != 0);
+                data.data.resize(num_entries * fields_per_entry * data.nodes_per_element);
+            };
+
+            size_t nodes_per_element;
+            for (size_t i = 0; i < num_entries; i++) {
+                in >> data.tags[i];
+                in >> nodes_per_element;
+                if (data.nodes_per_element == 0) {
+                    data.nodes_per_element = nodes_per_element;
+                    allocate_memory();
+                } else if (data.nodes_per_element != nodes_per_element) {
+                    throw InvalidFormat("Hybrid elements not supported in NodeElementData.");
+                }
+
+                for (size_t j = 0; j < nodes_per_element; j++) {
                     for (size_t k = 0; k < fields_per_entry; k++) {
-                        in >> entry.data[j * fields_per_entry + k];
+                        in >> data.data[i * nodes_per_element * fields_per_entry +
+                                        j * fields_per_entry + k];
                     }
                 }
-            } else {
-                entry.data.resize(fields_per_entry);
+            }
+        } else {
+            for (size_t i = 0; i < num_entries; i++) {
+                in >> data.tags[i];
                 for (size_t j = 0; j < fields_per_entry; j++) {
-                    in >> entry.data[j];
+                    in >> data.data[i * fields_per_entry + j];
                 }
             }
         }
     }
     assert(in.good());
+
+    // Copy data to legacy DataEntry structure.
+    data.entries.resize(num_entries);
+    size_t entry_data_size =
+        is_element_node_data ? fields_per_entry * data.nodes_per_element : fields_per_entry;
+    for (size_t i = 0; i < num_entries; i++) {
+        auto& entry = data.entries[i];
+        entry.tag = data.tags[i];
+        entry.num_nodes_per_element = static_cast<int>(data.nodes_per_element);
+        entry.data.resize(entry_data_size);
+        std::copy(std::next(data.data.begin(), static_cast<int>(i * entry_data_size)),
+            std::next(data.data.begin(), static_cast<int>((i + 1) * entry_data_size)),
+            entry.data.begin());
+    }
 }
 
 } // namespace internal

--- a/src/load_msh_elements.cpp
+++ b/src/load_msh_elements.cpp
@@ -154,7 +154,7 @@ void load_elements_binary(std::istream& in, MshSpec& spec)
 
         // Due to v2.2 constraints, each element is parsed as a separate block, and
         // a regrouping will happen at post-processing time.
-        for (size_t i = 0; i < num_elements_in_block; i++) {
+        for (int32_t i = 0; i < num_elements_in_block; i++) {
             in.read(reinterpret_cast<char*>(&element_id), 4);
             in.read(reinterpret_cast<char*>(tags.data()), 4 * num_tags);
             in.read(reinterpret_cast<char*>(node_ids.data()), static_cast<int>(4 * n));

--- a/src/load_msh_patches.cpp
+++ b/src/load_msh_patches.cpp
@@ -62,7 +62,8 @@ void load_patches_binary(std::istream& in, MshSpec& spec)
         patch.data.resize(num_entries);
         eat_white_space(in, 1);
 
-        in.read(reinterpret_cast<char*>(patch.data.data()), sizeof(double) * num_entries);
+        in.read(reinterpret_cast<char*>(patch.data.data()),
+            static_cast<std::streamsize>(sizeof(double) * num_entries));
     }
 #endif
 }

--- a/src/load_msh_physical_groups.cpp
+++ b/src/load_msh_physical_groups.cpp
@@ -1,6 +1,7 @@
 #include "load_msh_physical_groups.h"
 
 #include <mshio/MshSpec.h>
+#include <mshio/exception.h>
 
 #include <cassert>
 #include <fstream>
@@ -11,11 +12,14 @@ namespace mshio {
 
 void load_physical_groups(std::istream& in, MshSpec& spec)
 {
+    const bool is_ascii = spec.mesh_format.file_type == 0;
+    if (!is_ascii) throw UnsupportedFeature("Parsing binary physical groups is not supported!");
+
     auto& groups = spec.physical_groups;
-    int num_groups;
+    size_t num_groups;
     in >> num_groups;
     spec.physical_groups.resize(num_groups);
-    for (int i = 0; i < num_groups; i++) {
+    for (size_t i = 0; i < num_groups; i++) {
         auto& group = groups[i];
         in >> group.dim;
         in >> group.tag;

--- a/src/load_msh_post_process.cpp
+++ b/src/load_msh_post_process.cpp
@@ -25,8 +25,8 @@ void regroup_nodes_into_blocks(MshSpec& spec)
         for (size_t i = 0; i < block.num_elements_in_block; i++) {
             for (size_t j = 0; j < n; j++) {
                 size_t idx = node_index(block.data[i * (n + 1) + j + 1]);
-                entity_dims[idx] = block.entity_dim;
-                entity_tags[idx] = block.entity_tag;
+                entity_dims[idx] = static_cast<size_t>(block.entity_dim);
+                entity_tags[idx] = static_cast<size_t>(block.entity_tag);
             }
         }
     }
@@ -86,9 +86,9 @@ void regroup_elements_into_blocks(MshSpec& spec)
             curr_block.entity_tag = block.entity_tag;
             curr_block.element_type = block.element_type;
 
-            curr_dim = block.entity_dim;
-            curr_tag = block.entity_tag;
-            curr_element_type = block.element_type;
+            curr_dim = static_cast<size_t>(block.entity_dim);
+            curr_tag = static_cast<size_t>(block.entity_tag);
+            curr_element_type = static_cast<size_t>(block.element_type);
         }
 
         auto& curr_block = element_blocks.back();

--- a/src/load_msh_post_process.cpp
+++ b/src/load_msh_post_process.cpp
@@ -76,7 +76,7 @@ void regroup_elements_into_blocks(MshSpec& spec)
     std::vector<ElementBlock> element_blocks;
     element_blocks.reserve(elements.num_entity_blocks);
 
-    size_t curr_dim = 0, curr_tag = 0, curr_element_type = 0;
+    int curr_dim = 0, curr_tag = 0, curr_element_type = 0;
     for (auto& block : elements.entity_blocks) {
         if (block.entity_dim != curr_dim || block.entity_tag != curr_tag ||
             block.element_type != curr_element_type) {
@@ -86,9 +86,9 @@ void regroup_elements_into_blocks(MshSpec& spec)
             curr_block.entity_tag = block.entity_tag;
             curr_block.element_type = block.element_type;
 
-            curr_dim = static_cast<size_t>(block.entity_dim);
-            curr_tag = static_cast<size_t>(block.entity_tag);
-            curr_element_type = static_cast<size_t>(block.element_type);
+            curr_dim = block.entity_dim;
+            curr_tag = block.entity_tag;
+            curr_element_type = block.element_type;
         }
 
         auto& curr_block = element_blocks.back();

--- a/src/save_msh_curves.cpp
+++ b/src/save_msh_curves.cpp
@@ -63,7 +63,8 @@ void save_curves_binary(std::ostream& out, const MshSpec& spec)
         const size_t num_entries = curve.num_control_points * dim + curve.num_knots;
         assert(num_entries == curve.data.size());
 
-        out.write(reinterpret_cast<const char*>(curve.data.data()), sizeof(double) * num_entries);
+        out.write(reinterpret_cast<const char*>(curve.data.data()),
+            static_cast<std::streamsize>(sizeof(double) * num_entries));
     }
 #endif
 }

--- a/src/save_msh_data.cpp
+++ b/src/save_msh_data.cpp
@@ -12,74 +12,59 @@ namespace mshio {
 
 namespace internal {
 
+void save_data_header(std::ostream& out, const DataHeader& header)
+{
+    out << header.string_tags.size() << std::endl;
+    for (const std::string& tag : header.string_tags) {
+        out << std::quoted(tag) << std::endl;
+    }
+
+    out << header.real_tags.size() << std::endl;
+    for (const double& tag : header.real_tags) {
+        out << tag << std::endl;
+    }
+
+    out << header.int_tags.size() << std::endl;
+    for (const int& tag : header.int_tags) {
+        out << tag << std::endl;
+    }
+}
+
 void save_data(std::ostream& out,
     const Data& data,
     const std::string& version,
     bool is_binary,
     bool is_element_node_data)
 {
-    out << data.header.string_tags.size() << std::endl;
-    for (const std::string& tag : data.header.string_tags) {
-        out << std::quoted(tag) << std::endl;
-    }
+    save_data_header(out, data.header);
 
-    out << data.header.real_tags.size() << std::endl;
-    for (const double& tag : data.header.real_tags) {
-        out << tag << std::endl;
-    }
-
-    out << data.header.int_tags.size() << std::endl;
-    for (const int& tag : data.header.int_tags) {
-        out << tag << std::endl;
-    }
+    const size_t num_entries = data.tags.size();
+    const size_t entry_size = num_entries == 0 ? 0 : data.data.size() / num_entries;
+    assert(num_entries * entry_size == data.data.size());
 
     if (is_binary) {
-        if (version == "4.1") {
-            int32_t tag;
-            for (const DataEntry& entry : data.entries) {
-                // TODO:
-                // Based on trial and error, it seems Gmsh 4.7.1 still expect 32
-                // bits tag, which is inconsistent with their spec.  Maybe
-                // report a bug?
-                tag = static_cast<int32_t>(entry.tag);
-                out.write(reinterpret_cast<const char*>(&tag), 4);
-                // out.write(reinterpret_cast<const char*>(&entry.tag), sizeof(size_t));
-                if (is_element_node_data) {
-                    out.write(
-                        reinterpret_cast<const char*>(&entry.num_nodes_per_element), sizeof(int));
-                }
-                out.write(reinterpret_cast<const char*>(entry.data.data()),
-                    static_cast<std::streamsize>(sizeof(double) * entry.data.size()));
+        // Note that this diviates from the MSH spec for both v2.2 and v4.1.
+        // See bug report in https://github.com/qnzhou/MshIO/pull/1
+        int32_t tag, num_nodes_per_element = static_cast<int32_t>(data.nodes_per_element);
+        for (size_t i = 0; i < num_entries; i++) {
+            tag = static_cast<int32_t>(data.tags[i]);
+            out.write(reinterpret_cast<const char*>(&tag), 4);
+            if (is_element_node_data) {
+                out.write(reinterpret_cast<const char*>(&num_nodes_per_element), 4);
             }
-        } else if (version == "2.2") {
-            int32_t tag, num_nodes_per_element;
-            for (const DataEntry& entry : data.entries) {
-                tag = static_cast<int32_t>(entry.tag);
-                out.write(reinterpret_cast<const char*>(&tag), 4);
-                if (is_element_node_data) {
-                    num_nodes_per_element = static_cast<int32_t>(entry.num_nodes_per_element);
-                    out.write(reinterpret_cast<const char*>(&num_nodes_per_element), 4);
-                }
-                out.write(reinterpret_cast<const char*>(entry.data.data()),
-                    static_cast<std::streamsize>(sizeof(double) * entry.data.size()));
-            }
-        } else {
-            throw InvalidFormat("Unsupported version " + version);
+            out.write(reinterpret_cast<const char*>(data.data.data() + i * entry_size),
+                static_cast<std::streamsize>(sizeof(double) * entry_size));
         }
     } else {
-        for (const DataEntry& entry : data.entries) {
-            out << entry.tag << " ";
+        for (size_t i = 0; i < num_entries; i++) {
+            out << data.tags[i];
             if (is_element_node_data) {
-                out << entry.num_nodes_per_element << " ";
+                out << ' ' << data.nodes_per_element;
             }
-            for (size_t i = 0; i < entry.data.size(); i++) {
-                out << entry.data[i];
-                if (i == entry.data.size() - 1) {
-                    out << std::endl;
-                } else {
-                    out << ' ';
-                }
+            for (size_t j = 0; j < entry_size; j++) {
+                out << ' ' << data.data[i * entry_size + j];
             }
+            out << std::endl;
         }
     }
 }

--- a/src/save_msh_patches.cpp
+++ b/src/save_msh_patches.cpp
@@ -70,7 +70,8 @@ void save_patches_binary(std::ostream& out, const MshSpec& spec)
             patch.num_control_points * dim + patch.num_u_knots + patch.num_v_knots;
         assert(patch.data.size() == num_entries);
 
-        out.write(reinterpret_cast<const char*>(patch.data.data()), sizeof(double) * num_entries);
+        out.write(reinterpret_cast<const char*>(patch.data.data()),
+            static_cast<std::streamsize>(sizeof(double) * num_entries));
     }
 #endif
 }

--- a/tests/test_io.cpp
+++ b/tests/test_io.cpp
@@ -67,15 +67,9 @@ void ASSERT_SAME_NODE_DATA(const MshSpec& spec1, const MshSpec& spec2)
         REQUIRE(data1.header.string_tags == data2.header.string_tags);
         REQUIRE(data1.header.real_tags == data2.header.real_tags);
         REQUIRE(data1.header.int_tags == data2.header.int_tags);
-        REQUIRE(data1.entries.size() == data2.entries.size());
 
-        const size_t num_entries = data1.entries.size();
-        for (size_t j = 0; j < num_entries; j++) {
-            const auto& entry1 = data1.entries[j];
-            const auto& entry2 = data2.entries[j];
-            REQUIRE(entry1.tag == entry2.tag);
-            REQUIRE(entry1.data == entry2.data);
-        }
+        REQUIRE(data1.tags == data2.tags);
+        REQUIRE(data1.data == data2.data);
     }
 }
 
@@ -93,15 +87,9 @@ void ASSERT_SAME_ELEMENT_DATA(const MshSpec& spec1, const MshSpec& spec2)
         REQUIRE(data1.header.string_tags == data2.header.string_tags);
         REQUIRE(data1.header.real_tags == data2.header.real_tags);
         REQUIRE(data1.header.int_tags == data2.header.int_tags);
-        REQUIRE(data1.entries.size() == data2.entries.size());
 
-        const size_t num_entries = data1.entries.size();
-        for (size_t j = 0; j < num_entries; j++) {
-            const auto& entry1 = data1.entries[j];
-            const auto& entry2 = data2.entries[j];
-            REQUIRE(entry1.tag == entry2.tag);
-            REQUIRE(entry1.data == entry2.data);
-        }
+        REQUIRE(data1.tags == data2.tags);
+        REQUIRE(data1.data == data2.data);
     }
 }
 
@@ -119,16 +107,10 @@ void ASSERT_SAME_ELEMENT_NODE_DATA(const MshSpec& spec1, const MshSpec& spec2)
         REQUIRE(data1.header.string_tags == data2.header.string_tags);
         REQUIRE(data1.header.real_tags == data2.header.real_tags);
         REQUIRE(data1.header.int_tags == data2.header.int_tags);
-        REQUIRE(data1.entries.size() == data2.entries.size());
 
-        const size_t num_entries = data1.entries.size();
-        for (size_t j = 0; j < num_entries; j++) {
-            const auto& entry1 = data1.entries[j];
-            const auto& entry2 = data2.entries[j];
-            REQUIRE(entry1.tag == entry2.tag);
-            REQUIRE(entry1.num_nodes_per_element == entry2.num_nodes_per_element);
-            REQUIRE(entry1.data == entry2.data);
-        }
+        REQUIRE(data1.tags == data2.tags);
+        REQUIRE(data1.nodes_per_element == data2.nodes_per_element);
+        REQUIRE(data1.data == data2.data);
     }
 }
 
@@ -496,18 +478,10 @@ TEST_CASE("node data")
     attr.header.real_tags = {0};
     attr.header.int_tags = {0, 1, 2, 0};
 
-    DataEntry entry1;
-    entry1.tag = 1;
-    entry1.data = {1};
+    attr.tags = {1, 2};
+    attr.data = {1, 2};
 
-    DataEntry entry2;
-    entry2.tag = 2;
-    entry2.data = {2};
-
-    attr.entries.push_back(entry1);
-    attr.entries.push_back(entry2);
-
-    node_data.push_back(attr);
+    node_data.push_back(std::move(attr));
 
     validate_spec(spec);
     save_and_load(spec);
@@ -528,15 +502,11 @@ TEST_CASE("element data")
         attr.header.real_tags = {0};
         attr.header.int_tags = {0, 1, static_cast<int>(data.size()), 0, 3};
 
-        size_t tag = 9;
-        for (const auto& value : data) {
-            DataEntry entry;
-            entry.tag = tag;
-            entry.data = {value};
-            tag++;
-            attr.entries.push_back(std::move(entry));
-        }
-        node_data.push_back(attr);
+        attr.tags.resize(data.size());
+        std::iota(attr.tags.begin(), attr.tags.end(), 9);
+        attr.data = data;
+
+        node_data.push_back(std::move(attr));
     };
 
     auto add_element_data = [&](const std::string& name, const auto& data) {
@@ -547,16 +517,11 @@ TEST_CASE("element data")
         attr.header.real_tags = {0};
         attr.header.int_tags = {0, 1, static_cast<int>(data.size()), 0, 10};
 
-        size_t tag = 10;
-        for (const auto& value : data) {
-            DataEntry entry;
-            entry.tag = tag;
-            entry.data = {value};
-            tag++;
-            attr.entries.push_back(std::move(entry));
-        }
+        attr.tags.resize(data.size());
+        std::iota(attr.tags.begin(), attr.tags.end(), 10);
+        attr.data = data;
 
-        elem_data.push_back(attr);
+        elem_data.push_back(std::move(attr));
     };
 
     std::vector<double> values = {0, 1, 2, 3};
@@ -582,23 +547,99 @@ TEST_CASE("element node data")
         Data attr;
         attr.header.string_tags = {name};
         attr.header.real_tags = {0};
-        attr.header.int_tags = {0, 1, static_cast<int>(data.size()), 0, 10};
+        attr.header.int_tags = {0, 1, static_cast<int>(data.size() / 3), 0, 10};
 
-        size_t tag = 10;
-        for (const auto& value : data) {
-            DataEntry entry;
-            entry.tag = tag;
-            entry.num_nodes_per_element = 3;
-            entry.data = {value, value, value};
-            tag++;
-            attr.entries.push_back(std::move(entry));
-        }
+        attr.tags.resize(data.size() / 3);
+        std::iota(attr.tags.begin(), attr.tags.end(), 10);
+        attr.nodes_per_element = 3;
+        attr.data = data;
 
-        elem_node_data.push_back(attr);
+        elem_node_data.push_back(std::move(attr));
     };
 
-    std::vector<double> ids = {1.0};
+    std::vector<double> ids = {1.0, 2.0, 3.0};
     add_element_node_data("c index", ids);
+
+    validate_spec(spec);
+    save_and_load(spec);
+}
+
+TEST_CASE("all data", "[io][data]")
+{
+    using namespace mshio;
+
+    MshSpec spec;
+    SECTION("binary") { spec.mesh_format.file_type = 1; }
+    //SECTION("ascii") { spec.mesh_format.file_type = 0; }
+
+    // Add nodes
+    {
+        spec.nodes.num_entity_blocks = 1;
+        spec.nodes.num_nodes = 4;
+        spec.nodes.min_node_tag = 1;
+        spec.nodes.max_node_tag = 4;
+
+        NodeBlock block;
+        block.entity_dim = 2;
+        block.entity_tag = 1;
+        block.num_nodes_in_block = 4;
+        block.tags = {1, 2, 3, 4};
+        block.data = {0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0};
+        spec.nodes.entity_blocks.push_back(std::move(block));
+    }
+
+    // Add elements
+    {
+        spec.elements.num_entity_blocks = 1;
+        spec.elements.num_elements = 1;
+        spec.elements.min_element_tag = 1;
+        spec.elements.max_element_tag = 1;
+
+        ElementBlock block;
+        block.entity_dim = 2;
+        block.entity_tag = 1;
+        block.element_type = 3;
+        block.num_elements_in_block = 1;
+        block.data = {1, 1, 2, 3, 4};
+        spec.elements.entity_blocks.push_back(std::move(block));
+    }
+
+    // Add node data
+    {
+        Data attr;
+        attr.header.string_tags = {"node_id"};
+        attr.header.real_tags = {0};
+        attr.header.int_tags = {0, 1, 4, 1};
+
+        attr.tags = {1, 2, 3, 4};
+        attr.data = {1, 2, 3, 4};
+        spec.node_data.push_back(std::move(attr));
+    }
+
+    // Add element data
+    {
+        Data attr;
+        attr.header.string_tags = {"elem_normal"};
+        attr.header.real_tags = {0};
+        attr.header.int_tags = {0, 3, 1, 1};
+
+        attr.tags = {1};
+        attr.data = {0, 0, 1};
+        spec.element_data.push_back(std::move(attr));
+    }
+
+    // Add element node data
+    {
+        Data attr;
+        attr.header.string_tags = {"2D normal"};
+        attr.header.real_tags = {0};
+        attr.header.int_tags = {0, 3, 1, 1};
+
+        attr.nodes_per_element = 4;
+        attr.tags = {1};
+        attr.data = {-1, -1, 0, 1, -1, 0, 1, 1, 0, -1, 1, 0};
+        spec.element_node_data.push_back(std::move(attr));
+    }
 
     validate_spec(spec);
     save_and_load(spec);

--- a/tests/test_io.cpp
+++ b/tests/test_io.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <catch2/catch.hpp>
 #include <sstream>
 
@@ -570,7 +571,7 @@ TEST_CASE("all data", "[io][data]")
 
     MshSpec spec;
     SECTION("binary") { spec.mesh_format.file_type = 1; }
-    //SECTION("ascii") { spec.mesh_format.file_type = 0; }
+    // SECTION("ascii") { spec.mesh_format.file_type = 0; }
 
     // Add nodes
     {

--- a/tests/test_io.cpp
+++ b/tests/test_io.cpp
@@ -1,5 +1,5 @@
-#include <algorithm>
 #include <catch2/catch.hpp>
+#include <numeric>
 #include <sstream>
 
 #include <mshio/mshio.h>

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -60,3 +60,17 @@ class TestNodes:
         assert len(block.data) == 2
         assert block.data.shape[1] == 4
         assert np.all(block.data == facets)
+
+    def test_data(self):
+        data = mshio.Data()
+        data.header.string_tags = ["test"]
+        data.header.real_tags = [0.]
+        data.header.int_tags = [0, 1, 3, 1]
+
+        data.tags = np.array([1, 2, 3], dtype = int)
+        data.data = np.array([1., 2., 3.]).reshape((3, 1))
+
+        assert len(data.tags) == 3
+        assert np.all(data.tags == [1, 2, 3])
+        assert len(data.data) == 3
+        assert np.all(data.data.ravel() == [1., 2., 3.])


### PR DESCRIPTION
Summary:
* Refactor `mshio::Data` class such that data are contiguous and can be exposed in python as a numpy matrix.
* Deprecate old API.
* Refactor and warning fixes.
* More unit tests.